### PR TITLE
db410c: Add kernel-update script

### DIFF
--- a/scripts/db410c/kernel-update.sh
+++ b/scripts/db410c/kernel-update.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Update kernel with the one available in /boot directory
+
+BOOTIMG=${1:-/dev/disk/by-partlabel/boot}
+DT_ROOT=`dirname $0`/../..
+DBOOTIMG=`which dbootimg`
+DBOOTIMG=${DBOOTIMG:-${DT_ROOT}/tools/dbootimg/dbootimg}
+KERNEL=/boot/vmlinuz-$(uname -r)
+
+if [ ! -e ${KERNEL} ]; then
+	echo "Kernel ${KERNEL} does not exist"
+	exit 1
+fi
+
+if [ ! -e ${BOOTIMG} ]; then
+	echo "Invalid bootimg: ${BOOTIMG}"
+	exit 1
+fi
+
+echo "Updating kernel..."
+${DBOOTIMG} ${BOOTIMG} -u kernel ${KERNEL}
+
+echo "kernel updated, please reboot"
+sync


### PR DESCRIPTION
Not sure it should be part of **dt**-update... but it depends on dbootimg.

This script uses dbootimg tool to update bootimg kernel.
Kernel is replaced with the one available in /boot.
This mainly fixes kernel/module dealignment after apt-get upgrade.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>