### PR TITLE
dbootimg: Fix sigsegv while updating kernel with no dtb

### DIFF
--- a/tools/dbootimg/src/dbootimg.c
+++ b/tools/dbootimg/src/dbootimg.c
@@ -430,7 +430,7 @@ static void *aboot_update_dtb(void *boot, void *dtb, bool force)
 static void *aboot_update_kernel(void *boot, void *kernel)
 {
 	struct aboot_hdr *aboot, *old_aboot = boot;
-	ssize_t page_sz, kernel_sz, align_sz;
+	ssize_t page_sz, kernel_sz, align_sz, dtb_sz;
 	void *old_kernel, *dtb, *ptr;
 	int diff;
 
@@ -438,6 +438,7 @@ static void *aboot_update_kernel(void *boot, void *kernel)
 	old_kernel = aboot_get_kernel(old_aboot);
 	kernel_sz = kernelgz_size(kernel);
 	dtb = aboot_get_dtb(old_aboot);
+	dtb_sz = dtb ? dtb_size(dtb) : 0;
 
 	diff = kernel_sz - kernelgz_size(old_kernel);
 
@@ -457,11 +458,11 @@ static void *aboot_update_kernel(void *boot, void *kernel)
 	ptr += kernel_sz;
 
 	/* copy appended dtb */
-	memcpy(ptr, dtb, dtb_size(dtb));
-	ptr += dtb_size(dtb);
+	memcpy(ptr, dtb, dtb_sz);
+	ptr += dtb_sz;
 
 	/* modify kernel size (kernel.gz + dtb) */
-	aboot->kernel_size = cpu_to_le32(kernel_sz + dtb_size(dtb));
+	aboot->kernel_size = cpu_to_le32(kernel_sz + dtb_sz);
 
 	/* align on page */
 	align_sz = page_sz - le32_to_cpu(aboot->kernel_size) % page_sz;


### PR DESCRIPTION
Trying to update a kernel with no appended dtb resulted in:

root@qt5506:~# dbootimg /dev/disk/by-partlabel/boot -u kernel /boot/Image.gz
DTB not found in boot image
[ 2130.770995] audit: type=1701 audit(1533805111.476:2): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=3453 comm="dbootimg" exe="/usr/bin/dbootimg" sig=11 res=1
Segmentation fault (core dumped)

This patch allows upding the dtb IIF the old image contained an appended
dtb.

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>